### PR TITLE
Framerate granularity

### DIFF
--- a/lib/cardanim.lua
+++ b/lib/cardanim.lua
@@ -6,6 +6,7 @@ if not G.cardanim then
 		card_layers = {},
 		-- later added here: animation_macros = {}
 		-- DO NOT ADD animation_details = {} here, its existence is checked by the loading event
+		framerate_granularity = 2
 	}
 end
 
@@ -60,6 +61,7 @@ G.E_MANAGER:add_event(Event({
 			return true
 		end
 
+		local granularity = G.cardanim.framerate_granularity
 		-- Register animations
 		G.cardanim.animation_details = {}
 		local anim_details = G.cardanim.animation_details
@@ -95,7 +97,7 @@ G.E_MANAGER:add_event(Event({
 
 		-- Start animation update
 		local sprite_dt = 0
-		local sprite_spf = 0.10 -- seconds per frame
+		local sprite_spf = 0.1/granularity -- seconds per frame
 		local _game_update = Game.update -- hella sus, akin to performing brain surgery on yourself
 		function Game:update(dt)
 			_game_update(self, dt)
@@ -128,7 +130,8 @@ G.E_MANAGER:add_event(Event({
 						if not frame.t then
 							frame.t = 1
 						end
-						if frame.t == frame_dur[kw] then
+						local proper_t = frame.t*granularity
+						if proper_t <= frame_dur[kw] then
 							frame_i[kw] = frame_i[kw] + 1 -- increase frame
 							if frame_i[kw] > #frame_seq[kw] then
 								frame_i[kw] = 1


### PR DESCRIPTION
The fork adds a new `G.cardanim` parameter, `framerate_granularity`, an integer value that specifies how many frames run within a 0.1 second duration. By setting `framerate_granularity`, the `t` parameter on each frame can now take a duration less than 1.

For example, if `framerate_granularity`=2, `t` can now equal 0.5, 1, 1.5, 2...
and if `framerate_granularity`=3, `t` can now equal 0.333, 0.666, 1, 1.333, 1.666, 2...
and in general, `t` takes multiples of the value `1/framerate_granularity`.

Best results occur if `framerate_granularity` equals 1 or a multiple of 2 or 5 (example: 2, 4, 5, 8, 10) (non-example: 3, 6, 7, 11).